### PR TITLE
now working with ET; BA in Inf has changed to MO, fixed

### DIFF
--- a/src/model/ParsePDF.java
+++ b/src/model/ParsePDF.java
@@ -228,6 +228,14 @@ public class ParsePDF extends Observable{
                     	return true;
                 if(vector.elementAt(index).indexOf("BA") > -1)
                 		return true;
+                if(vector.elementAt(index).indexOf("MO") > -1)
+        				return true;
+        		if(vector.elementAt(index).indexOf("LN") > -1)
+        				return true;
+        		if(vector.elementAt(index).indexOf("LA") > -1)
+        				return true;
+        		if(vector.elementAt(index).indexOf("TL") > -1)
+        				return true;
                 else
                         return false;
         }
@@ -253,8 +261,18 @@ public class ParsePDF extends Observable{
          * @return Credit Points
          */
         public String getCredit(Vector<String> vector, int index) {
-                int startCreditPosition = vector.elementAt(index).indexOf("BE")+3; // Position of BE, warning if the exam title have BE, may cause parsing error!!
-                int endCreditPosition = vector.elementAt(index).indexOf("BE")+5; // Position of BE
+        		int startCreditPosition, endCreditPosition;
+        		if (subject.equals("Fach: Elektrotechnik und Informationstechnik")) {
+	        			startCreditPosition = vector.elementAt(index).indexOf("BE")+2; // Position of BE, warning if the exam title have BE, may cause parsing error!!
+	                	endCreditPosition = vector.elementAt(index).indexOf("BE")+4; // Position of BE
+	                	// if half credit points
+	                	if (vector.elementAt(index).charAt(endCreditPosition-1) == ',') {
+	            			endCreditPosition++;
+	            		}
+        		} else {
+	                	startCreditPosition = vector.elementAt(index).indexOf("BE")+3; // Position of BE, warning if the exam title have BE, may cause parsing error!!
+	                	endCreditPosition = vector.elementAt(index).indexOf("BE")+5; // Position of BE
+        		}
                 String credit = vector.elementAt(index).substring(startCreditPosition,endCreditPosition);
                 
                 return credit;


### PR DESCRIPTION
Hi,
I changed it to read also files for ET which produced garbage before because of half credit points resulting in different spaces between BE and credit points. Additionally they don't have PL, SL only, they have LN, LA, TL and MO, too.
In Inf they changed the BA to MO resulting in the BA not getting acknowledged. Since I introduced MO because of ET this was fixed the same way.
There is still a problem with the BA because they only write 12 points for it and in the headline they write 15 because of the oral part. So in my case it's only 98% progress even though I'm already done.
I didn't fix it because it is not trivial and I guess nobody cares anyway because if they got the BA they are nearly finished and will have the correct overview in time.
While I'm at it: Thanks for this nice piece of software, well commented.
Have a nice day!
